### PR TITLE
fix: allow running postgres_docs concurrently for different versions

### DIFF
--- a/ingest/postgres_docs.py
+++ b/ingest/postgres_docs.py
@@ -522,7 +522,14 @@ def main():
         checkout_tag(tag)
         build_html()
         build_markdown()
-        chunk_files(conn, version)
+        try:
+            chunk_files(conn, version)
+        except Exception as e:
+            with conn.cursor() as cur:
+                cur.execute(SQL("drop table if exists {table}").format(table=TMP_CHUNKS_TABLE))
+                cur.execute(SQL("drop table if exists {table}").format(table=TMP_PAGES_TABLE))
+                conn.commit()
+            raise e
 
 
 if __name__ == "__main__":

--- a/ingest/postgres_docs.py
+++ b/ingest/postgres_docs.py
@@ -429,7 +429,7 @@ def chunk_files(conn: psycopg.Connection, version: int) -> None:
     )
     conn.execute(
         SQL(
-            "alter table {chunks_table} add foreign key (page_id) references {pages_table}}(id) on delete cascade"
+            "alter table {chunks_table} add foreign key (page_id) references {pages_table}(id) on delete cascade"
         ).format(chunks_table=TMP_CHUNKS_TABLE, pages_table=TMP_PAGES_TABLE)
     )
     conn.commit()

--- a/ingest/postgres_docs.py
+++ b/ingest/postgres_docs.py
@@ -43,10 +43,10 @@ TMP_ID = (
     .replace("+", "_")
 )
 TMP_CHUNKS_TABLE = SQL("{schema}.{table}").format(
-    Identifier("docs"), Identifier(f"postgres_chunks_tmp_{TMP_ID}")
+    schema=Identifier("docs"), table=Identifier(f"postgres_chunks_tmp_{TMP_ID}")
 )
 TMP_PAGES_TABLE = SQL("{schema}.{table}").format(
-    Identifier("docs"), Identifier(f"postgres_pages_tmp_{TMP_ID}")
+    schema=Identifier("docs"), table=Identifier(f"postgres_pages_tmp_{TMP_ID}")
 )
 
 

--- a/ingest/postgres_docs.py
+++ b/ingest/postgres_docs.py
@@ -1,6 +1,7 @@
 import argparse
 from dataclasses import dataclass
 from dotenv import load_dotenv
+import base64
 from bs4 import BeautifulSoup, element as BeautifulSoupElement
 import json
 from markdownify import markdownify
@@ -9,12 +10,11 @@ import os
 from pathlib import Path
 import psycopg
 from psycopg.sql import SQL, Identifier
-import random
 import re
 import shutil
-import string
 import subprocess
 import tiktoken
+import uuid
 
 
 THIS_DIR = Path(__file__).parent.resolve()
@@ -35,7 +35,7 @@ POSTGRES_BASE_URL = "https://www.postgresql.org/docs"
 ENC = tiktoken.get_encoding("cl100k_base")
 MAX_CHUNK_TOKENS = 7000
 
-TMP_ID = "".join(random.choices(string.ascii_letters + string.digits, k=6))
+TMP_ID = base64.urlsafe_b64encode(uuid.uuid4().bytes).rstrip(b"=").decode("ascii").replace('-', '_').replace('+', '_')
 TMP_CHUNKS_TABLE = Identifier(f"docs.postgres_chunks_{TMP_ID}")
 TMP_PAGES_TABLE = Identifier(f"docs.postgres_pages_{TMP_ID}")
 

--- a/ingest/postgres_docs.py
+++ b/ingest/postgres_docs.py
@@ -429,8 +429,8 @@ def chunk_files(conn: psycopg.Connection, version: int) -> None:
     )
     conn.execute(
         SQL(
-            "alter table {table} add foreign key (page_id) references docs.postgres_pages_tmp(id) on delete cascade"
-        ).format(table=TMP_CHUNKS_TABLE)
+            "alter table {chunks_table} add foreign key (page_id) references {pages_table}}(id) on delete cascade"
+        ).format(chunks_table=TMP_CHUNKS_TABLE, pages_table=TMP_PAGES_TABLE)
     )
     conn.commit()
 


### PR DESCRIPTION
PR fixes a bug where on trying to run `postgres_docs.py` simultaneously for multiple different versions, then would end up with collisions on using the same base tmp table. We now append a uuid to the tmp table name to ensure uniqueness for a given run.