### PR TITLE
chore: get feature-branch workflows working

### DIFF
--- a/.github/workflows/build-on-feature-branch.yaml
+++ b/.github/workflows/build-on-feature-branch.yaml
@@ -20,7 +20,7 @@ jobs:
               ref: 'main',
               inputs: {
                 repository: 'tiger-docs-mcp-server',
-                ref: ${{ github.ref }},
-                sha: ${{ github.sha }}
+                ref: '${{ github.ref }}',
+                sha: '${{ github.sha }}'
               }
             })

--- a/.github/workflows/build-on-feature-branch.yaml
+++ b/.github/workflows/build-on-feature-branch.yaml
@@ -5,16 +5,22 @@ on:
       - main
 
 jobs:
-  release:
-    name: Build Docker
-    uses: timescale/cloud-actions/.github/workflows/build.yaml@main
-    with:
-      tags: |
-        auto-${{ github.sha }}
-      registry: 142548018081.dkr.ecr.us-east-1.amazonaws.com/tiger-docs-mcp-server
-      dockerfile_path: ./Dockerfile
-      skip-scan: true
-    secrets:
-      API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.ORG_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.ORG_AWS_SECRET_ACCESS_KEY }}
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch build-on-feature-branch workflow
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GH_AGENTS_PAT }}
+          script: |
+            await github.actions.createWorkflowDispatch({
+              owner: 'timescale',
+              repo: 'tiger-agents-deploy',
+              workflow_id: 'build-on-feature-branch.yaml',
+              ref: 'main',
+              inputs: {
+                repository: 'tiger-docs-mcp-server',
+                ref: ${{ github.ref }}
+                sha: ${{ github.sha }}
+              }
+            })

--- a/.github/workflows/build-on-feature-branch.yaml
+++ b/.github/workflows/build-on-feature-branch.yaml
@@ -13,7 +13,7 @@ jobs:
         with:
           github-token: ${{ secrets.GH_AGENTS_PAT }}
           script: |
-            await github.actions.createWorkflowDispatch({
+            await github.rest.actions.createWorkflowDispatch({
               owner: 'timescale',
               repo: 'tiger-agents-deploy',
               workflow_id: 'build-on-feature-branch.yaml',

--- a/.github/workflows/build-on-feature-branch.yaml
+++ b/.github/workflows/build-on-feature-branch.yaml
@@ -20,7 +20,7 @@ jobs:
               ref: 'main',
               inputs: {
                 repository: 'tiger-docs-mcp-server',
-                ref: ${{ github.ref }}
+                ref: ${{ github.ref }},
                 sha: ${{ github.sha }}
               }
             })

--- a/.github/workflows/deploy-feature-branch.yaml
+++ b/.github/workflows/deploy-feature-branch.yaml
@@ -18,7 +18,6 @@ jobs:
               ref: 'main',
               inputs: {
                 repository: 'tiger-docs-mcp-server',
-                ref: '${{ github.ref }}',
                 sha: '${{ github.sha }}'
               }
             })

--- a/.github/workflows/deploy-feature-branch.yaml
+++ b/.github/workflows/deploy-feature-branch.yaml
@@ -4,32 +4,21 @@ on:
 
 jobs:
   deploy:
-    name: Deploy dev us-east-1
-    uses: timescale/cloud-actions/.github/workflows/deploy.yaml@main
-    with:
-      env: dev
-      region: us-east-1
-      tag: auto-${{ github.sha }}
-      registry: 142548018081.dkr.ecr.us-east-1.amazonaws.com/tiger-docs-mcp-server
-      chart_name: tiger-docs-mcp-server
-      chart_namespace: savannah-system
-      helm_timeout: 20m
-    secrets:
-      API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-      ORG_AWS_ACCESS_KEY_ID: ${{ secrets.ORG_AWS_ACCESS_KEY_ID }}
-      ORG_AWS_SECRET_ACCESS_KEY: ${{ secrets.ORG_AWS_SECRET_ACCESS_KEY }}
-      ORG_KUBECONFIG_DEV: ${{ secrets.ORG_KUBECONFIG_DEV_US_EAST_1_1 }}
-      ORG_KUBECONFIG_DEV_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_DEV_EU_CENTRAL_1 }}
-      ORG_KUBECONFIG_DEV_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_DEV_US_WEST_2 }}
-      ORG_KUBECONFIG_PROD: ${{ secrets.ORG_KUBECONFIG_PROD }}
-      ORG_KUBECONFIG_PROD_AP_NORTHEAST_1: ${{ secrets.ORG_KUBECONFIG_PROD_AP_NORTHEAST_1 }}
-      ORG_KUBECONFIG_PROD_AP_SOUTHEAST_1: ${{ secrets.ORG_KUBECONFIG_PROD_AP_SOUTHEAST_1 }}
-      ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2: ${{ secrets.ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2 }}
-      ORG_KUBECONFIG_PROD_CA_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_PROD_CA_CENTRAL_1 }}
-      ORG_KUBECONFIG_PROD_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_CENTRAL_1 }}
-      ORG_KUBECONFIG_PROD_EU_WEST_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_WEST_1 }}
-      ORG_KUBECONFIG_PROD_EU_WEST_2: ${{ secrets.ORG_KUBECONFIG_PROD_EU_WEST_2 }}
-      ORG_KUBECONFIG_PROD_SA_EAST_1: ${{ secrets.ORG_KUBECONFIG_PROD_SA_EAST_1 }}
-      ORG_KUBECONFIG_PROD_US_EAST_2: ${{ secrets.ORG_KUBECONFIG_PROD_US_EAST_2 }}
-      ORG_KUBECONFIG_PROD_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_PROD_US_WEST_2 }}
-      ORG_KUBECONFIG_PROD_AP_SOUTH_1: ${{ secrets.ORG_KUBECONFIG_PROD_AP_SOUTH_1 }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch build-on-feature-branch workflow
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GH_AGENTS_PAT }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'timescale',
+              repo: 'tiger-agents-deploy',
+              workflow_id: 'deploy-feature-branch.yaml',
+              ref: 'main',
+              inputs: {
+                repository: 'tiger-docs-mcp-server',
+                ref: '${{ github.ref }}',
+                sha: '${{ github.sha }}'
+              }
+            })


### PR DESCRIPTION
PR fixes the `build-on-feature-branch` and `deploy-feature-branch` workflows so that they function again, and this can be used as a basis of agreeing that this is the right way to accomplish this.

The current problem is that the `timescale/cloud-actions` repo relies on being passed a number of secrets that are only accessible by private repos. When we made this repo public, it then broke the workflow as we no longer had access to those secrets.

The solution is to standup an [intermediary repository](https://github.com/timescale/tiger-agents-deploy) that this repo triggers to do any sort of builds or deploys that are needed. This repo is then responsible for triggering the necessary https://github.com/timescale/cloud-actions workfows. The biggest nuisance here is then the need for modifying `cloud-actions` to allow setting arbitrary repository/ref information so that `actions/checkout` continues to work as expected. This is accomplished by https://github.com/timescale/cloud-actions/pull/73. This intermediary repository would then also hold our helm charts for deploying the service as well.