### PR TITLE
feat: run prod and dev ingests in parallel

### DIFF
--- a/.github/workflows/ingest-postgres-docs.yaml
+++ b/.github/workflows/ingest-postgres-docs.yaml
@@ -1,4 +1,5 @@
 name: Ingest PostgreSQL Docs
+
 on:
   workflow_dispatch:
     inputs:
@@ -8,13 +9,20 @@ on:
         default: '17'
 
 jobs:
-  ingest:
-    name: Ingest PostgreSQL Docs
+  ingest-dev:
+    name: Ingest PostgreSQL Docs For Dev
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ingest
-    steps:
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      PGHOST: ${{ secrets.PGHOST }}
+      PGPORT: ${{ secrets.PGPORT }}
+      PGDATABASE: ${{ secrets.PGDATABASE }}
+      PGUSER: ${{ secrets.PGUSER }}
+      PGPASSWORD: ${{ secrets.PGPASSWORD }}
+    steps: &ingest-steps
       - name: Checkout repository
         uses: actions/checkout@v5
 
@@ -35,21 +43,19 @@ jobs:
           sudo apt-get install -y docbook-xml docbook-xsl libxml2-utils xsltproc fop
 
       - name: Ingest PostgreSQL ${{ github.event.inputs.version }} docs for dev
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PGHOST: ${{ secrets.PGHOST }}
-          PGPORT: ${{ secrets.PGPORT }}
-          PGDATABASE: ${{ secrets.PGDATABASE }}
-          PGUSER: ${{ secrets.PGUSER }}
-          PGPASSWORD: ${{ secrets.PGPASSWORD }}
         run: uv run python postgres_docs.py ${{ github.event.inputs.version }}
 
-      - name: Ingest PostgreSQL ${{ github.event.inputs.version }} docs for prod
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PGHOST: ${{ secrets.PROD_PGHOST }}
-          PGPORT: ${{ secrets.PROD_PGPORT }}
-          PGDATABASE: ${{ secrets.PROD_PGDATABASE }}
-          PGUSER: ${{ secrets.PROD_PGUSER }}
-          PGPASSWORD: ${{ secrets.PROD_PGPASSWORD }}
-        run: uv run python postgres_docs.py ${{ github.event.inputs.version }}
+  ingest-prod:
+    name: Ingest PostgreSQL Docs For Dev
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ingest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      PGHOST: ${{ secrets.PROD_PGHOST }}
+      PGPORT: ${{ secrets.PROD_PGPORT }}
+      PGDATABASE: ${{ secrets.PROD_PGDATABASE }}
+      PGUSER: ${{ secrets.PROD_PGUSER }}
+      PGPASSWORD: ${{ secrets.PROD_PGPASSWORD }}
+    steps: *ingest-steps

--- a/.github/workflows/ingest-postgres-docs.yaml
+++ b/.github/workflows/ingest-postgres-docs.yaml
@@ -1,4 +1,5 @@
 name: Ingest PostgreSQL Docs
+run-name: Ingest PostgreSQL ${{ inputs.version }} Docs
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ingest-timescale-docs.yaml
+++ b/.github/workflows/ingest-timescale-docs.yaml
@@ -1,17 +1,25 @@
 name: Ingest Timescale Docs
+
 on:
   schedule:
     - cron: '0 2 * * 0'
   workflow_dispatch:
 
 jobs:
-  ingest:
+  ingest-dev:
     name: Ingest Timescale Docs
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ingest
-    steps:
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      PGHOST: ${{ secrets.PGHOST }}
+      PGPORT: ${{ secrets.PGPORT }}
+      PGDATABASE: ${{ secrets.PGDATABASE }}
+      PGUSER: ${{ secrets.PGUSER }}
+      PGPASSWORD: ${{ secrets.PGPASSWORD }}
+    steps: &ingest-steps
       - name: Checkout repository
         uses: actions/checkout@v5
 
@@ -26,22 +34,20 @@ jobs:
       - name: Install python dependencies
         run: uv sync
 
-      - name: Ingest Timescale docs for dev
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PGHOST: ${{ secrets.PGHOST }}
-          PGPORT: ${{ secrets.PGPORT }}
-          PGDATABASE: ${{ secrets.PGDATABASE }}
-          PGUSER: ${{ secrets.PGUSER }}
-          PGPASSWORD: ${{ secrets.PGPASSWORD }}
+      - name: Ingest Timescale docs
         run: uv run python timescale_docs.py
 
-      - name: Ingest Timescale docs for prod
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PGHOST: ${{ secrets.PROD_PGHOST }}
-          PGPORT: ${{ secrets.PROD_PGPORT }}
-          PGDATABASE: ${{ secrets.PROD_PGDATABASE }}
-          PGUSER: ${{ secrets.PROD_PGUSER }}
-          PGPASSWORD: ${{ secrets.PROD_PGPASSWORD }}
-        run: uv run python timescale_docs.py
+  ingest-prod:
+    name: Ingest Timescale Docs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ingest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      PGHOST: ${{ secrets.PROD_PGHOST }}
+      PGPORT: ${{ secrets.PROD_PGPORT }}
+      PGDATABASE: ${{ secrets.PROD_PGDATABASE }}
+      PGUSER: ${{ secrets.PROD_PGUSER }}
+      PGPASSWORD: ${{ secrets.PROD_PGPASSWORD }}
+    steps: *ingest-steps


### PR DESCRIPTION
PR modifes the postgres and timescale ingest workflows so that we process and ingest into prod and dev in parallel jobs. This keeps the overall runtime of the two consistent with how it was before (e.g. ~20 minutes) instead of doubling it.

To DRY this, I make use of the new [YAML anchors](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases) feature in GHA that was released a week ago ([announcement](https://docs.github.com/en/actions/concepts/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases)).