### PR TITLE
Add tool to use bm25 search

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,8 +1,10 @@
 import { semanticSearchPostgresDocsFactory } from './semanticSearchPostgresDocs.js';
 import { semanticSearchTigerDocsFactory } from './semanticSearchTigerDocs.js';
 import { getPromptContentFactory } from './getGuide.js';
+import { keywordSearchTigerDocsFactory } from './kewordSearchTigerDocs.js';
 
 export const apiFactories = [
+  keywordSearchTigerDocsFactory,
   semanticSearchPostgresDocsFactory,
   semanticSearchTigerDocsFactory,
   getPromptContentFactory,

--- a/src/apis/kewordSearchTigerDocs.ts
+++ b/src/apis/kewordSearchTigerDocs.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+import { openai } from '@ai-sdk/openai';
+import { embed } from 'ai';
+import { ApiFactory } from '../shared/boilerplate/src/types.js';
+import { ServerContext } from '../types.js';
+
+const inputSchema = {
+  limit: z.coerce
+    .number()
+    .min(1)
+    .nullable()
+    .describe('The maximum number of matches to return. Defaults to 10.'),
+  keywords: z
+    .string()
+    .min(1)
+    .describe(
+      'The set of keywords to search for.',
+    ),
+} as const;
+
+const zEmbeddedDoc = z.object({
+  id: z
+    .number()
+    .int()
+    .describe('The unique identifier of the documentation entry.'),
+  content: z.string().describe('The content of the documentation entry.'),
+  metadata: z
+    .string()
+    .describe(
+      'Additional metadata about the documentation entry, as a JSON encoded string.',
+    ),
+  score: z
+    .number()
+    .describe(
+      'The score indicating the relevance of the entry to the keywords. Lower values indicate higher relevance.',
+    ),
+});
+
+type EmbeddedDoc = z.infer<typeof zEmbeddedDoc>;
+
+const outputSchema = {
+  results: z.array(zEmbeddedDoc),
+} as const;
+
+export const keywordSearchTigerDocsFactory: ApiFactory<
+  ServerContext,
+  typeof inputSchema,
+  typeof outputSchema,
+  z.infer<(typeof outputSchema)['results']>
+> = ({ pgPool, schema }) => ({
+  name: 'keywordSearchTigerDocs',
+  method: 'get',
+  route: '/keyword-search/tiger-docs',
+  config: {
+    title: 'Keyword Search of Tiger Documentation',
+    description:
+      'This retrieves relevancy ranked documentation entries based on a set of keywords, using a bm25 search. The content covers Tiger Cloud and TimescaleDB topics.',
+    inputSchema,
+    outputSchema,
+  },
+  disabled: process.env.ENABLE_KEYWORD_SEARCH !== 'true',
+  fn: async ({ keywords, limit }) => {
+    const result = await pgPool.query<EmbeddedDoc>(
+      /* sql */ `
+SELECT
+  id::int,
+  content,
+  metadata::text,
+  content <@> to_tpquery($1, 'docs.timescale_chunks_content_idx') as score
+ FROM ${schema}.timescale_chunks
+ ORDER BY score
+ LIMIT $2
+`,
+      [keywords, limit || 10],
+    );
+
+    return {
+      results: result.rows,
+    };
+  },
+  pickResult: (r) => r.results,
+});


### PR DESCRIPTION
This adds a new tool to perform keyword searching of Tiger docs, alongside the existing semantic search. This will be disabled by default, as it is not ready to be deployed to the public/hosted instance, and will only function on develeopment databases.
