### PR TITLE
fix: import of ApiFactory in getPromptTemplates

### DIFF
--- a/src/apis/getPromptTemplate.ts
+++ b/src/apis/getPromptTemplate.ts
@@ -1,5 +1,5 @@
+import { ApiFactory } from '@tigerdata/mcp-boilerplate';
 import { z } from 'zod';
-import { ApiFactory } from '../shared/boilerplate/src/types.js';
 import { ServerContext } from '../types.js';
 import { prompts } from '../prompts/index.js';
 


### PR DESCRIPTION
PR fixes a build failure introduced by #25 where it didn't incorporate the new code from #27 in using `@tigerdata/mcp-boilerplate` instead of referencing the `src/shared/boilerplate` git submodule, since the two PRs were merged at roughly the same time.