### PR TITLE
Use name as title

### DIFF
--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -21,6 +21,8 @@ function loadPrompts() {
 
     promptsMap.set(promptName, {
       name: promptName,
+      // Using the snake_case name as the title to work around a problem in Claude Code
+      // See https://github.com/anthropics/claude-code/issues/7464
       title: promptName,
       description: data.description,
       content: content.trim(),


### PR DESCRIPTION
Claude code appears to have a bug where it uses the prompt's `title` instead of its `name`, and chokes on it if it contains whitespace characters. This changes uses the existing `name` for the `title` as well, making them consistently use snake_case, and work around the problem for now.

More detail in [slack](https://iobeam.slack.com/archives/C099S47CSRX/p1761078168570189)