### PR TITLE
fix: change SELECT to CALL for add_columnstore_policy procedure

### DIFF
--- a/src/prompts/md/migrate_to_hypertables.md
+++ b/src/prompts/md/migrate_to_hypertables.md
@@ -144,7 +144,7 @@ ALTER TABLE your_table_name SET (
 );
 
 -- Compress after data unlikely to change (adjust `after` parameter based on update patterns)
-SELECT add_columnstore_policy('your_table_name', after => INTERVAL '7 days');
+CALL add_columnstore_policy('your_table_name', after => INTERVAL '7 days');
 ```
 
 ## Step 2: Migration Planning
@@ -184,7 +184,7 @@ ALTER TABLE your_table_name SET (
 );
 
 -- Adjust `after` parameter based on update patterns
-SELECT add_columnstore_policy('your_table_name', after => INTERVAL '7 days');
+CALL add_columnstore_policy('your_table_name', after => INTERVAL '7 days');
 ```
 
 #### Option 2: Blue-Green (Tables > 1GB)

--- a/src/prompts/md/setup_hypertable.md
+++ b/src/prompts/md/setup_hypertable.md
@@ -170,7 +170,7 @@ Set `after` interval for when: data becomes mostly immutable (some updates/backf
 
 ```sql
 -- Adjust 'after' based on update patterns
-SELECT add_columnstore_policy('your_table_name', after => INTERVAL '1 day');
+CALL add_columnstore_policy('your_table_name', after => INTERVAL '1 day');
 ```
 
 ## Step 3: Retention Policy
@@ -304,7 +304,7 @@ ALTER MATERIALIZED VIEW your_table_hourly SET (
     timescaledb.segmentby = 'entity_id, category',
     timescaledb.orderby = 'bucket DESC'
 );
-SELECT add_columnstore_policy('your_table_hourly', after => INTERVAL '3 days');
+CALL add_columnstore_policy('your_table_hourly', after => INTERVAL '3 days');
 
 -- Daily
 ALTER MATERIALIZED VIEW your_table_daily SET (
@@ -312,7 +312,7 @@ ALTER MATERIALIZED VIEW your_table_daily SET (
     timescaledb.segmentby = 'entity_id, category',
     timescaledb.orderby = 'bucket DESC'
 );
-SELECT add_columnstore_policy('your_table_daily', after => INTERVAL '7 days');
+CALL add_columnstore_policy('your_table_daily', after => INTERVAL '7 days');
 ```
 
 ## Step 8: Aggregate Retention


### PR DESCRIPTION
## Summary

Fixed incorrect SQL syntax in prompt documentation files where `add_columnstore_policy` was being called with `SELECT` instead of `CALL`. Since `add_columnstore_policy` is a procedure (not a function), it must be invoked with `CALL`.

- Fixed 5 instances across 2 prompt files
- `src/prompts/md/migrate_to_hypertables.md`: 2 instances
- `src/prompts/md/setup_hypertable.md`: 3 instances

## Test plan

- [ ] Review the diff to confirm all `SELECT add_columnstore_policy(...)` statements have been changed to `CALL add_columnstore_policy(...)`
- [ ] Verify that no other procedures in the codebase are incorrectly using SELECT
- [ ] Confirm the SQL syntax is now correct for TimescaleDB procedure calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)