### PR TITLE
fix schema definitions for broader compatibillity

### DIFF
--- a/src/apis/semanticSearchTigerDocs.ts
+++ b/src/apis/semanticSearchTigerDocs.ts
@@ -7,12 +7,10 @@ import { ServerContext } from '../types.js';
 const inputSchema = {
   limit: z.coerce
     .number()
-    .min(1)
-    .nullable()
+    .int()
     .describe('The maximum number of matches to return. Defaults to 10.'),
   prompt: z
     .string()
-    .min(1)
     .describe(
       'The natural language query used to search the documentation for relevant information.',
     ),
@@ -61,6 +59,13 @@ export const semanticSearchTigerDocsFactory: ApiFactory<
     outputSchema,
   },
   fn: async ({ prompt, limit }): Promise<OutputSchema> => {
+    if (limit < 0) {
+      throw new Error('Limit must be a non-negative integer.');
+    }
+    if (!prompt.trim()) {
+      throw new Error('Prompt must be a non-empty string.');
+    }
+
     const { embedding } = await embed({
       model: openai.embedding('text-embedding-3-small'),
       value: prompt,


### PR DESCRIPTION
When testing compatibility with Google Antigravity, we discovered that Sonnet via the Vertex provider does not work with MCP servers that define tools with parameters that have `minLength` annotations on their type. We've had similar problems with other models/providers:

- Cannot use type arrays with Gemini models (e.g. `type: ["string", "null"]`)
  - Zod prefers to output this format when possible, and `.min()` annotations were a convenient workaround to output the `anyOf` notation instead
- Should avoid optional parameters for compatibility with GPT-5 (responses API) in strict mode (though many clients shim this by setting `strict: false`)

This led to the following decisions in this PR:

- All inputs are required
- Removed all useage of `.nullable()`
- Empty/zero inputs are treated as "use the default" where reasonably possible
- Use strict `.enum()` definitions where reasonable (e.g. postgres major version selection)
- Write additional validation in the implementation, where zod validators must be avoided
