### PR TITLE
Add npx skills support with postgres router skill

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,5 @@ jobs:
         run: ./bun run lint
       - name: Typecheck
         run: ./bun run typecheck
+      - name: Validate skills
+        run: ./bun run validate-skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 - Build: `./bun run build` - Compiles TypeScript to JavaScript
 - Watch mode: `./bun run watch http` - Watches for changes and rebuilds automatically
 - Run server: `./bun run start stdio` - Starts the MCP server using stdio transport
+- Checks: `./bun run check` - All-in-one command to lint and test. Run before every commit.
 
 ## Code Style Guidelines
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ pg-aiguide helps AI coding tools write dramatically better PostgreSQL code. It p
 - **AI-optimized “skills”** — curated, opinionated Postgres best practices used automatically by AI agents
 - **Extension ecosystem docs**, starting with TimescaleDB, with more coming soon
 
-Use it either as:
+Use it as:
 
+- **Agent Skills** via `npx skills` — works with Claude Code, Cursor, Codex, Gemini CLI, and 40+ other agents
 - a **public MCP server** that can be used with any AI coding agent, or
 - a **Claude Code plugin** optimized for use with Claude's native skill support.
 
@@ -49,7 +50,27 @@ Conclusion: _pg-aiguide produces more robust, performant, maintainable schemas._
 
 ## 🚀 Quickstart
 
-pg-aiguide is available as a **public MCP server**:
+### Agent Skills
+
+Install curated PostgreSQL best-practice skills for your AI coding agent:
+
+```bash
+npx skills add timescale/pg-aiguide --skill postgres
+```
+
+Or pick individual skills interactively:
+
+```bash
+npx skills add timescale/pg-aiguide
+```
+
+Works with Claude Code, Cursor, Codex, Gemini CLI, VS Code, and [40+ other agents](https://agentskills.io).
+
+For even deeper PostgreSQL knowledge, also add the [MCP server](#mcp-server) to give your agent semantic search over the official PostgreSQL, TimescaleDB, and PostGIS manuals.
+
+### MCP Server
+
+For semantic search over PostgreSQL, TimescaleDB, and PostGIS documentation, add the **public MCP server**:
 
 [https://mcp.tigerdata.com/docs](https://mcp.tigerdata.com/docs)
 
@@ -75,9 +96,7 @@ claude plugin marketplace add timescale/pg-aiguide
 claude plugin install pg@aiguide
 ```
 
-### Install by environment
-
-#### One-click installs
+#### Install by environment
 
 [![Install in Cursor](https://img.shields.io/badge/Install_in-Cursor-000000?style=flat-square&logoColor=white)](https://cursor.com/en/install-mcp?name=pg-aiguide&config=eyJuYW1lIjoicGctYWlndWlkZSIsInR5cGUiOiJodHRwIiwidXJsIjoiaHR0cHM6Ly9tY3AudGlnZXJkYXRhLmNvbS9kb2NzIn0=)
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=pg-aiguide&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.tigerdata.com%2Fdocs%22%7D)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "tsc && shx chmod +x dist/*.js",
     "inspector": "./bun x @modelcontextprotocol/inspector",
     "lint": "biome check",
+    "validate-skills": "./bun scripts/validate-skills.ts",
     "migrate": "migrate",
     "prepublishOnly": "./bun run build",
     "start": "./bun src/index.ts",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",
+    "check": "./bun i --silent && ./bun run typecheck && ./bun run lint --write && ./bun run validate-skills && ./bun test --only-failures",
     "inspector": "./bun x @modelcontextprotocol/inspector",
     "lint": "biome check",
     "validate-skills": "./bun scripts/validate-skills.ts",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && shx chmod +x dist/*.js",
+    "build": "tsc -p tsconfig.build.json && shx chmod +x dist/*.js",
     "check": "./bun i --silent && ./bun run typecheck && ./bun run lint --write && ./bun run validate-skills && ./bun test --only-failures",
     "inspector": "./bun x @modelcontextprotocol/inspector",
     "lint": "biome check",

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -9,10 +9,10 @@
  * - SKILL.md body: recommended <500 lines
  */
 
-import { readFileSync, readdirSync, statSync, lstatSync } from "node:fs";
-import { join, basename } from "node:path";
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, join } from 'node:path';
 
-const SKILLS_DIR = join(import.meta.dirname, "..", "skills");
+const SKILLS_DIR = join(import.meta.dirname, '..', 'skills');
 const NAME_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
 const MAX_NAME_LENGTH = 64;
 const MAX_DESCRIPTION_LENGTH = 1024;
@@ -21,7 +21,7 @@ const MAX_BODY_LINES = 500;
 interface ValidationError {
   skill: string;
   message: string;
-  severity: "error" | "warning";
+  severity: 'error' | 'warning';
 }
 
 function parseFrontmatter(content: string): Record<string, string> | null {
@@ -52,16 +52,16 @@ function parseFrontmatter(content: string): Record<string, string> | null {
 function validateSkill(skillDir: string): ValidationError[] {
   const errors: ValidationError[] = [];
   const dirName = basename(skillDir);
-  const skillMdPath = join(skillDir, "SKILL.md");
+  const skillMdPath = join(skillDir, 'SKILL.md');
 
   let content: string;
   try {
-    content = readFileSync(skillMdPath, "utf-8");
+    content = readFileSync(skillMdPath, 'utf-8');
   } catch {
     errors.push({
       skill: dirName,
-      message: "Missing SKILL.md file",
-      severity: "error",
+      message: 'Missing SKILL.md file',
+      severity: 'error',
     });
     return errors;
   }
@@ -70,8 +70,8 @@ function validateSkill(skillDir: string): ValidationError[] {
   if (!fm) {
     errors.push({
       skill: dirName,
-      message: "Missing or malformed YAML frontmatter",
-      severity: "error",
+      message: 'Missing or malformed YAML frontmatter',
+      severity: 'error',
     });
     return errors;
   }
@@ -80,36 +80,36 @@ function validateSkill(skillDir: string): ValidationError[] {
   if (!fm.name) {
     errors.push({
       skill: dirName,
-      message: "Missing required field: name",
-      severity: "error",
+      message: 'Missing required field: name',
+      severity: 'error',
     });
   } else {
     if (fm.name.length > MAX_NAME_LENGTH) {
       errors.push({
         skill: dirName,
         message: `name exceeds ${MAX_NAME_LENGTH} chars (${fm.name.length})`,
-        severity: "error",
+        severity: 'error',
       });
     }
     if (!NAME_REGEX.test(fm.name)) {
       errors.push({
         skill: dirName,
         message: `name "${fm.name}" must be lowercase alphanumeric with hyphens, no leading/trailing/consecutive hyphens`,
-        severity: "error",
+        severity: 'error',
       });
     }
-    if (fm.name.includes("--")) {
+    if (fm.name.includes('--')) {
       errors.push({
         skill: dirName,
         message: `name "${fm.name}" contains consecutive hyphens`,
-        severity: "error",
+        severity: 'error',
       });
     }
     if (fm.name !== dirName) {
       errors.push({
         skill: dirName,
         message: `name "${fm.name}" does not match directory name "${dirName}"`,
-        severity: "error",
+        severity: 'error',
       });
     }
   }
@@ -118,26 +118,26 @@ function validateSkill(skillDir: string): ValidationError[] {
   if (!fm.description) {
     errors.push({
       skill: dirName,
-      message: "Missing required field: description",
-      severity: "error",
+      message: 'Missing required field: description',
+      severity: 'error',
     });
   } else if (fm.description.length > MAX_DESCRIPTION_LENGTH) {
     errors.push({
       skill: dirName,
       message: `description exceeds ${MAX_DESCRIPTION_LENGTH} chars (${fm.description.length})`,
-      severity: "error",
+      severity: 'error',
     });
   }
 
   // Check body line count
   const bodyMatch = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
   if (bodyMatch) {
-    const bodyLines = bodyMatch[1].split("\n").length;
+    const bodyLines = bodyMatch[1].split('\n').length;
     if (bodyLines > MAX_BODY_LINES) {
       errors.push({
         skill: dirName,
         message: `SKILL.md body is ${bodyLines} lines (recommended max: ${MAX_BODY_LINES}). Consider splitting into references/`,
-        severity: "warning",
+        severity: 'warning',
       });
     }
   }
@@ -162,10 +162,10 @@ let hasWarnings = false;
 for (const dir of dirs) {
   const errors = validateSkill(dir);
   for (const err of errors) {
-    const prefix = err.severity === "error" ? "ERROR" : "WARN";
+    const prefix = err.severity === 'error' ? 'ERROR' : 'WARN';
     console.log(`${prefix}: [${err.skill}] ${err.message}`);
-    if (err.severity === "error") hasErrors = true;
-    if (err.severity === "warning") hasWarnings = true;
+    if (err.severity === 'error') hasErrors = true;
+    if (err.severity === 'warning') hasWarnings = true;
   }
 }
 

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -30,20 +30,21 @@ function parseFrontmatter(content: string): Record<string, string> | null {
 
   const fm: Record<string, string> = {};
   const raw = match[1];
+  if (!raw) return fm;
 
   // Extract name (single line)
   const nameMatch = raw.match(/^name:\s*(.+)$/m);
-  if (nameMatch) fm.name = nameMatch[1].trim();
+  if (nameMatch?.[1]) fm.name = nameMatch[1].trim();
 
   // Extract description (may be multi-line with | syntax)
   const descMatch = raw.match(
     /^description:\s*\|?\s*\n([\s\S]*?)(?=\n[a-z][\w-]*:|\n?$)/m,
   );
-  if (descMatch) {
+  if (descMatch?.[1]) {
     fm.description = descMatch[1].trim();
   } else {
     const singleDescMatch = raw.match(/^description:\s*(.+)$/m);
-    if (singleDescMatch) fm.description = singleDescMatch[1].trim();
+    if (singleDescMatch?.[1]) fm.description = singleDescMatch[1].trim();
   }
 
   return fm;
@@ -131,7 +132,7 @@ function validateSkill(skillDir: string): ValidationError[] {
 
   // Check body line count
   const bodyMatch = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
-  if (bodyMatch) {
+  if (bodyMatch?.[1]) {
     const bodyLines = bodyMatch[1].split('\n').length;
     if (bodyLines > MAX_BODY_LINES) {
       errors.push({

--- a/scripts/validate-skills.ts
+++ b/scripts/validate-skills.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+/**
+ * Validates all SKILL.md files against the Agent Skills spec (https://agentskills.io/specification).
+ *
+ * Checks:
+ * - name: required, 1-64 chars, lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, matches directory name
+ * - description: required, 1-1024 chars
+ * - SKILL.md body: recommended <500 lines
+ */
+
+import { readFileSync, readdirSync, statSync, lstatSync } from "node:fs";
+import { join, basename } from "node:path";
+
+const SKILLS_DIR = join(import.meta.dirname, "..", "skills");
+const NAME_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+const MAX_NAME_LENGTH = 64;
+const MAX_DESCRIPTION_LENGTH = 1024;
+const MAX_BODY_LINES = 500;
+
+interface ValidationError {
+  skill: string;
+  message: string;
+  severity: "error" | "warning";
+}
+
+function parseFrontmatter(content: string): Record<string, string> | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  const fm: Record<string, string> = {};
+  const raw = match[1];
+
+  // Extract name (single line)
+  const nameMatch = raw.match(/^name:\s*(.+)$/m);
+  if (nameMatch) fm.name = nameMatch[1].trim();
+
+  // Extract description (may be multi-line with | syntax)
+  const descMatch = raw.match(
+    /^description:\s*\|?\s*\n([\s\S]*?)(?=\n[a-z][\w-]*:|\n?$)/m,
+  );
+  if (descMatch) {
+    fm.description = descMatch[1].trim();
+  } else {
+    const singleDescMatch = raw.match(/^description:\s*(.+)$/m);
+    if (singleDescMatch) fm.description = singleDescMatch[1].trim();
+  }
+
+  return fm;
+}
+
+function validateSkill(skillDir: string): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const dirName = basename(skillDir);
+  const skillMdPath = join(skillDir, "SKILL.md");
+
+  let content: string;
+  try {
+    content = readFileSync(skillMdPath, "utf-8");
+  } catch {
+    errors.push({
+      skill: dirName,
+      message: "Missing SKILL.md file",
+      severity: "error",
+    });
+    return errors;
+  }
+
+  const fm = parseFrontmatter(content);
+  if (!fm) {
+    errors.push({
+      skill: dirName,
+      message: "Missing or malformed YAML frontmatter",
+      severity: "error",
+    });
+    return errors;
+  }
+
+  // Validate name
+  if (!fm.name) {
+    errors.push({
+      skill: dirName,
+      message: "Missing required field: name",
+      severity: "error",
+    });
+  } else {
+    if (fm.name.length > MAX_NAME_LENGTH) {
+      errors.push({
+        skill: dirName,
+        message: `name exceeds ${MAX_NAME_LENGTH} chars (${fm.name.length})`,
+        severity: "error",
+      });
+    }
+    if (!NAME_REGEX.test(fm.name)) {
+      errors.push({
+        skill: dirName,
+        message: `name "${fm.name}" must be lowercase alphanumeric with hyphens, no leading/trailing/consecutive hyphens`,
+        severity: "error",
+      });
+    }
+    if (fm.name.includes("--")) {
+      errors.push({
+        skill: dirName,
+        message: `name "${fm.name}" contains consecutive hyphens`,
+        severity: "error",
+      });
+    }
+    if (fm.name !== dirName) {
+      errors.push({
+        skill: dirName,
+        message: `name "${fm.name}" does not match directory name "${dirName}"`,
+        severity: "error",
+      });
+    }
+  }
+
+  // Validate description
+  if (!fm.description) {
+    errors.push({
+      skill: dirName,
+      message: "Missing required field: description",
+      severity: "error",
+    });
+  } else if (fm.description.length > MAX_DESCRIPTION_LENGTH) {
+    errors.push({
+      skill: dirName,
+      message: `description exceeds ${MAX_DESCRIPTION_LENGTH} chars (${fm.description.length})`,
+      severity: "error",
+    });
+  }
+
+  // Check body line count
+  const bodyMatch = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+  if (bodyMatch) {
+    const bodyLines = bodyMatch[1].split("\n").length;
+    if (bodyLines > MAX_BODY_LINES) {
+      errors.push({
+        skill: dirName,
+        message: `SKILL.md body is ${bodyLines} lines (recommended max: ${MAX_BODY_LINES}). Consider splitting into references/`,
+        severity: "warning",
+      });
+    }
+  }
+
+  return errors;
+}
+
+// Run validation
+const dirs = readdirSync(SKILLS_DIR)
+  .map((d) => join(SKILLS_DIR, d))
+  .filter((d) => {
+    try {
+      return statSync(d).isDirectory();
+    } catch {
+      return false;
+    }
+  });
+
+let hasErrors = false;
+let hasWarnings = false;
+
+for (const dir of dirs) {
+  const errors = validateSkill(dir);
+  for (const err of errors) {
+    const prefix = err.severity === "error" ? "ERROR" : "WARN";
+    console.log(`${prefix}: [${err.skill}] ${err.message}`);
+    if (err.severity === "error") hasErrors = true;
+    if (err.severity === "warning") hasWarnings = true;
+  }
+}
+
+if (!hasErrors && !hasWarnings) {
+  console.log(`All ${dirs.length} skills pass spec validation.`);
+}
+
+if (hasErrors) {
+  process.exit(1);
+}

--- a/skills/design-postgis-tables/SKILL.md
+++ b/skills/design-postgis-tables/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: design-postgis-tables
 description: Comprehensive PostGIS spatial table design reference covering geometry types, coordinate systems, spatial indexing, and performance patterns for location-based applications
+license: Apache-2.0
+compatibility: Requires PostgreSQL 15+ with the PostGIS extension
+metadata:
+  author: tigerdata
 ---
 
 # PostGIS Spatial Table Design

--- a/skills/design-postgres-tables/SKILL.md
+++ b/skills/design-postgres-tables/SKILL.md
@@ -14,6 +14,9 @@ description: |
   **Keywords:** PostgreSQL schema, table design, data types, PRIMARY KEY, FOREIGN KEY, indexes, B-tree, GIN, JSONB, constraints, normalization, identity columns, partitioning, row-level security
 
   Comprehensive reference covering data types, indexing strategies, constraints, JSONB patterns, partitioning, and PostgreSQL-specific best practices.
+license: Apache-2.0
+metadata:
+  author: tigerdata
 ---
 
 # PostgreSQL Table Design

--- a/skills/find-hypertable-candidates/SKILL.md
+++ b/skills/find-hypertable-candidates/SKILL.md
@@ -14,6 +14,10 @@ description: |
   **Keywords:** hypertable candidate, table analysis, migration assessment, Timescale, TimescaleDB, time-series detection, insert-heavy tables, event logs, audit tables
 
   Provides SQL queries to analyze table statistics, index patterns, and query patterns. Includes scoring criteria (8+ points = good candidate) and pattern recognition for IoT, events, transactions, and sequential data.
+license: Apache-2.0
+compatibility: Requires PostgreSQL 15+ with TimescaleDB
+metadata:
+  author: tigerdata
 ---
 
 # PostgreSQL Hypertable Candidate Analysis

--- a/skills/migrate-postgres-tables-to-hypertables/SKILL.md
+++ b/skills/migrate-postgres-tables-to-hypertables/SKILL.md
@@ -15,6 +15,10 @@ description: |
   **Keywords:** migrate to hypertable, convert table, Timescale, TimescaleDB, blue-green migration, in-place conversion, create_hypertable, migration validation, compression setup
 
   Step-by-step migration planning including: partition column selection, chunk interval calculation, PK/constraint handling, migration execution (in-place vs blue-green), and performance validation queries.
+license: Apache-2.0
+compatibility: Requires PostgreSQL 15+ with TimescaleDB
+metadata:
+  author: tigerdata
 ---
 
 # PostgreSQL to TimescaleDB Hypertable Migration

--- a/skills/pgvector-semantic-search/SKILL.md
+++ b/skills/pgvector-semantic-search/SKILL.md
@@ -14,6 +14,10 @@ description: |
   **Keywords:** pgvector, embeddings, semantic search, vector similarity, HNSW, IVFFlat, halfvec, cosine distance, nearest neighbor, RAG, LLM, AI search
 
   Covers: halfvec storage, HNSW index configuration (m, ef_construction, ef_search), quantization strategies, filtered search, bulk loading, and performance tuning.
+license: Apache-2.0
+compatibility: Requires PostgreSQL 15+ with the pgvector extension
+metadata:
+  author: tigerdata
 ---
 
 # pgvector for Semantic Search

--- a/skills/postgres-hybrid-text-search/SKILL.md
+++ b/skills/postgres-hybrid-text-search/SKILL.md
@@ -14,6 +14,10 @@ description: |
   **Keywords:** hybrid search, BM25, pg_textsearch, RRF, reciprocal rank fusion, keyword search, full-text search, reranking, cross-encoder
 
   Covers: pg_textsearch BM25 index setup, parallel query patterns, client-side RRF fusion (Python/TypeScript), weighting strategies, and optional ML reranking.
+license: Apache-2.0
+compatibility: Requires PostgreSQL 15+ with pgvector and pg_textsearch extensions
+metadata:
+  author: tigerdata
 ---
 
 # Hybrid Text Search

--- a/skills/postgres/SKILL.md
+++ b/skills/postgres/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: postgres
+description: |
+  Use this skill for any PostgreSQL database work — table design, indexing, data types, constraints, extensions (pgvector, PostGIS, TimescaleDB), search, and migrations.
+
+  **Trigger when user asks to:**
+  - Design or modify PostgreSQL tables, schemas, or data models
+  - Choose data types, constraints, indexes, or partitioning strategies
+  - Work with pgvector embeddings, semantic search, or RAG
+  - Set up full-text search, hybrid search, or BM25 ranking
+  - Use PostGIS for spatial/geographic data
+  - Set up TimescaleDB hypertables for time-series data
+  - Migrate tables to hypertables or evaluate migration candidates
+
+  **Keywords:** PostgreSQL, Postgres, SQL, schema, table design, indexes, constraints, pgvector, PostGIS, TimescaleDB, hypertable, semantic search, hybrid search, BM25, time-series
+license: Apache-2.0
+metadata:
+  author: tigerdata
+---
+
+# PostgreSQL Expert Skills
+
+This skill provides comprehensive PostgreSQL expertise through specialized references. Load the appropriate reference based on the task.
+
+## Available References
+
+### Table Design
+- **[design-postgres-tables](references/design-postgres-tables.md)** — Data types, constraints, indexes, JSONB patterns, partitioning, and PostgreSQL best practices. **Use for any general table/schema design task.**
+- **[design-postgis-tables](references/design-postgis-tables.md)** — PostGIS spatial table design: geometry vs geography types, SRIDs, spatial indexing, and location-based query patterns. **Use when the task involves geographic or spatial data.**
+
+### Search
+- **[pgvector-semantic-search](references/pgvector-semantic-search.md)** — Vector similarity search with pgvector: HNSW/IVFFlat indexes, halfvec storage, quantization, filtered search, and tuning. **Use for embeddings, RAG, or semantic search.**
+- **[postgres-hybrid-text-search](references/postgres-hybrid-text-search.md)** — Hybrid search combining BM25 keyword search with pgvector semantic search using RRF. **Use when combining keyword and meaning-based search.**
+
+### TimescaleDB
+- **[setup-timescaledb-hypertables](references/setup-timescaledb-hypertables.md)** — Hypertable creation, compression, retention policies, continuous aggregates, and indexes. **Use when setting up TimescaleDB from scratch.**
+- **[find-hypertable-candidates](references/find-hypertable-candidates.md)** — SQL queries to analyze existing tables and score them for hypertable conversion. **Use when evaluating which tables to migrate.**
+- **[migrate-postgres-tables-to-hypertables](references/migrate-postgres-tables-to-hypertables.md)** — Step-by-step migration: partition column selection, in-place vs blue-green, validation. **Use when executing a migration.**
+
+## How to Use
+
+1. Identify which reference matches the user's task from the descriptions above.
+2. Load the reference file to get detailed instructions and SQL patterns.
+3. For tasks spanning multiple areas (e.g., "design a table with vector search"), load multiple references as needed.

--- a/skills/postgres/references/design-postgis-tables.md
+++ b/skills/postgres/references/design-postgis-tables.md
@@ -1,0 +1,1 @@
+../../design-postgis-tables/SKILL.md

--- a/skills/postgres/references/design-postgres-tables.md
+++ b/skills/postgres/references/design-postgres-tables.md
@@ -1,0 +1,1 @@
+../../design-postgres-tables/SKILL.md

--- a/skills/postgres/references/find-hypertable-candidates.md
+++ b/skills/postgres/references/find-hypertable-candidates.md
@@ -1,0 +1,1 @@
+../../find-hypertable-candidates/SKILL.md

--- a/skills/postgres/references/migrate-postgres-tables-to-hypertables.md
+++ b/skills/postgres/references/migrate-postgres-tables-to-hypertables.md
@@ -1,0 +1,1 @@
+../../migrate-postgres-tables-to-hypertables/SKILL.md

--- a/skills/postgres/references/pgvector-semantic-search.md
+++ b/skills/postgres/references/pgvector-semantic-search.md
@@ -1,0 +1,1 @@
+../../pgvector-semantic-search/SKILL.md

--- a/skills/postgres/references/postgres-hybrid-text-search.md
+++ b/skills/postgres/references/postgres-hybrid-text-search.md
@@ -1,0 +1,1 @@
+../../postgres-hybrid-text-search/SKILL.md

--- a/skills/postgres/references/setup-timescaledb-hypertables.md
+++ b/skills/postgres/references/setup-timescaledb-hypertables.md
@@ -1,0 +1,1 @@
+../../setup-timescaledb-hypertables/SKILL.md

--- a/skills/setup-timescaledb-hypertables/SKILL.md
+++ b/skills/setup-timescaledb-hypertables/SKILL.md
@@ -13,6 +13,10 @@ description: |
   **Keywords:** CREATE TABLE, hypertable, Timescale, TimescaleDB, time-series, IoT, metrics, sensor data, compression policy, continuous aggregates, columnstore, retention policy, chunk interval, segment_by, order_by
 
   Step-by-step instructions for hypertable creation, column selection, compression policies, retention, continuous aggregates, and indexes.
+license: Apache-2.0
+compatibility: Requires PostgreSQL 15+ with TimescaleDB
+metadata:
+  author: tigerdata
 ---
 
 # TimescaleDB Complete Setup

--- a/src/util/featureFlags.test.ts
+++ b/src/util/featureFlags.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { parseFeatureFlags } from './featureFlags.js';
+
+describe('parseFeatureFlags', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.DISABLE_MCP_SKILLS;
+    delete process.env.DISABLE_MCP_SKILLS;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.DISABLE_MCP_SKILLS = originalEnv;
+    } else {
+      delete process.env.DISABLE_MCP_SKILLS;
+    }
+  });
+
+  describe('defaults', () => {
+    test('returns skills enabled when no query or env var', () => {
+      const flags = parseFeatureFlags();
+      expect(flags.mcpSkillsEnabled).toBe(true);
+    });
+
+    test('returns skills enabled for empty query', () => {
+      const flags = parseFeatureFlags({});
+      expect(flags.mcpSkillsEnabled).toBe(true);
+    });
+  });
+
+  describe('query parameters (HTTP transport)', () => {
+    test('disables skills when disable_mcp_skills is "1"', () => {
+      const flags = parseFeatureFlags({ disable_mcp_skills: '1' });
+      expect(flags.mcpSkillsEnabled).toBe(false);
+    });
+
+    test('disables skills when disable_mcp_skills is "true"', () => {
+      const flags = parseFeatureFlags({ disable_mcp_skills: 'true' });
+      expect(flags.mcpSkillsEnabled).toBe(false);
+    });
+
+    test('keeps skills enabled for disable_mcp_skills "0"', () => {
+      const flags = parseFeatureFlags({ disable_mcp_skills: '0' });
+      expect(flags.mcpSkillsEnabled).toBe(true);
+    });
+
+    test('keeps skills enabled for disable_mcp_skills "false"', () => {
+      const flags = parseFeatureFlags({ disable_mcp_skills: 'false' });
+      expect(flags.mcpSkillsEnabled).toBe(true);
+    });
+
+    test('keeps skills enabled for unrelated query params', () => {
+      const flags = parseFeatureFlags({ other_param: 'value' });
+      expect(flags.mcpSkillsEnabled).toBe(true);
+    });
+
+    test('query takes precedence over env var', () => {
+      process.env.DISABLE_MCP_SKILLS = '1';
+      const flags = parseFeatureFlags({ disable_mcp_skills: '0' });
+      expect(flags.mcpSkillsEnabled).toBe(true);
+    });
+  });
+
+  describe('environment variables (stdio transport)', () => {
+    test('disables skills when DISABLE_MCP_SKILLS is "1"', () => {
+      process.env.DISABLE_MCP_SKILLS = '1';
+      const flags = parseFeatureFlags();
+      expect(flags.mcpSkillsEnabled).toBe(false);
+    });
+
+    test('disables skills when DISABLE_MCP_SKILLS is "true"', () => {
+      process.env.DISABLE_MCP_SKILLS = 'true';
+      const flags = parseFeatureFlags();
+      expect(flags.mcpSkillsEnabled).toBe(false);
+    });
+
+    test('keeps skills enabled for DISABLE_MCP_SKILLS "0"', () => {
+      process.env.DISABLE_MCP_SKILLS = '0';
+      const flags = parseFeatureFlags();
+      expect(flags.mcpSkillsEnabled).toBe(true);
+    });
+
+    test('keeps skills enabled for DISABLE_MCP_SKILLS "false"', () => {
+      process.env.DISABLE_MCP_SKILLS = 'false';
+      const flags = parseFeatureFlags();
+      expect(flags.mcpSkillsEnabled).toBe(true);
+    });
+
+    test('keeps skills enabled for unexpected DISABLE_MCP_SKILLS value', () => {
+      process.env.DISABLE_MCP_SKILLS = 'yes';
+      const flags = parseFeatureFlags();
+      expect(flags.mcpSkillsEnabled).toBe(true);
+    });
+
+    test('env var is ignored when query is provided', () => {
+      process.env.DISABLE_MCP_SKILLS = '1';
+      const flags = parseFeatureFlags({});
+      expect(flags.mcpSkillsEnabled).toBe(true);
+    });
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "./",
     "target": "ESNext",
     "module": "Preserve",
     "moduleResolution": "bundler",
@@ -17,6 +17,6 @@
     "sourceMap": true,
     "inlineSources": true
   },
-  "include": ["./src/**/*.ts"],
+  "include": ["./src/**/*.ts", "./scripts/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- Create `postgres/` router skill that bundles all 7 specialized skills via symlinked references, enabling progressive disclosure through the Agent Skills spec
- Add spec-compliant frontmatter to all skills: `license` (Apache-2.0), `compatibility` (where extensions required), `metadata.author`
- Update README with `npx skills` install instructions alongside the existing MCP server setup

Users can now install via:
```bash
npx skills add timescale/pg-aiguide --skill postgres   # all-in-one
npx skills add timescale/pg-aiguide                     # interactive picker
```

## Test plan
- [ ] Verify `npx skills add timescale/pg-aiguide --list` discovers all 8 skills (7 specialized + postgres router)
- [ ] Verify `npx skills add timescale/pg-aiguide --skill postgres` installs the router with working symlinked references
- [ ] Verify individual skill install still works
- [ ] Verify existing MCP server still loads skills correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)