### PR TITLE
fix(ingest): validate stored index definitions before re-execution

### DIFF
--- a/ingest/document_importer.py
+++ b/ingest/document_importer.py
@@ -15,6 +15,60 @@ from ingest.types import Chunk, Page, PageSource
 from ingest.utils.chunking import chunk_markdown_lines
 from psycopg.sql import SQL, Identifier
 
+# Strict allow-list pattern for CREATE INDEX statements returned by
+# pg_get_indexdef(). PostgreSQL renders these in a canonical form like:
+#   CREATE [UNIQUE] INDEX <name> ON <schema>.<table> [USING <method>] (...)
+# We re-execute these strings verbatim in finalize_database(), so we must
+# refuse anything that does not match the expected shape and target table.
+# This guards against a second-order SQL injection where a malicious or
+# unexpected index definition stored in the catalog (e.g. by a user with
+# DDL access) would otherwise be executed with the importer's privileges.
+_INDEX_DEF_RE = re.compile(
+    r"""
+    ^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+      # CREATE [UNIQUE] INDEX
+    (?:IF\s+NOT\s+EXISTS\s+)?
+    "?[A-Za-z_][A-Za-z0-9_]*"?\s+            # index name (optionally quoted)
+    ON\s+
+    (?:"?docs"?\.)?"?(?P<table>[A-Za-z_][A-Za-z0-9_]*)"?  # [docs.]<table>
+    \s+
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def _validate_index_def(index_def: str, expected_table: str) -> str:
+    """Validate that ``index_def`` is a CREATE INDEX targeting ``expected_table``.
+
+    Returns the original string on success; raises :class:`ValueError`
+    otherwise. Rejects stacked statements (semicolons outside the trailing
+    terminator) so a crafted catalog entry cannot smuggle additional SQL.
+    """
+    if not isinstance(index_def, str):
+        raise ValueError(f"Unexpected index definition type: {type(index_def)!r}")
+
+    # Strip a single trailing semicolon if present, then ensure no further
+    # statement separators remain.
+    stripped = index_def.strip().rstrip(";").strip()
+    if ";" in stripped:
+        raise ValueError(
+            f"Refusing to execute multi-statement index definition: {index_def!r}"
+        )
+
+    match = _INDEX_DEF_RE.match(stripped)
+    if not match:
+        raise ValueError(
+            f"Index definition does not match expected CREATE INDEX shape: {index_def!r}"
+        )
+
+    target_table = match.group("table")
+    if target_table != expected_table:
+        raise ValueError(
+            "Index definition targets unexpected table "
+            f"{target_table!r} (expected {expected_table!r}): {index_def!r}"
+        )
+
+    return stripped
+
 
 class DocumentImporter(ABC):
     def __init__(self, version: str | int, pages_table: str, chunks_table: str):
@@ -131,7 +185,10 @@ class DocumentImporter(ABC):
         print("Initializing database tables...")
 
         # Capture existing index definitions so we can recreate them after swap.
-        self._index_defs_to_create = [
+        # Each definition is validated against a strict allow-list before being
+        # stored, so finalize_database() can never execute an unexpected
+        # statement even if the catalog is tampered with between the two phases.
+        raw_index_defs = [
             row[0]
             for row in conn.execute(
                 """
@@ -143,6 +200,9 @@ class DocumentImporter(ABC):
                 """,
                 [self.chunks_table],
             ).fetchall()
+        ]
+        self._index_defs_to_create = [
+            _validate_index_def(d, self.chunks_table) for d in raw_index_defs
         ]
 
         conn.execute(f"DROP TABLE IF EXISTS docs.{self.chunks_table}_tmp CASCADE")
@@ -203,7 +263,11 @@ class DocumentImporter(ABC):
             )
 
             for index_def in self._index_defs_to_create:
-                cur.execute(index_def)
+                # Re-validate just before execution as defence in depth: the
+                # list is only ever populated through _validate_index_def in
+                # init_database(), but we don't want to depend on that
+                # invariant if the class is subclassed or refactored.
+                cur.execute(_validate_index_def(index_def, self.chunks_table))
 
             for table in [self.pages_table, self.chunks_table]:
                 cur.execute(

--- a/ingest/tests/test_index_def_validation.py
+++ b/ingest/tests/test_index_def_validation.py
@@ -1,0 +1,58 @@
+"""Tests for CREATE INDEX statement validation in document_importer.
+
+These guard against second-order SQL injection: ``finalize_database`` re-runs
+the ``indexdef`` strings captured from ``pg_indexes`` during ``init_database``.
+A malicious or unexpected catalog entry must not be able to smuggle additional
+SQL or target a table other than the importer's own chunks table.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ingest.document_importer import _validate_index_def
+
+
+@pytest.mark.parametrize(
+    "index_def",
+    [
+        "CREATE UNIQUE INDEX chunks_pkey ON docs.chunks USING btree (id)",
+        "CREATE INDEX idx_chunks_page_id ON docs.chunks USING btree (page_id)",
+        (
+            "CREATE INDEX chunks_bm25_idx ON docs.chunks "
+            "USING bm25 (id, content) WITH (key_field=id)"
+        ),
+        # Trailing semicolon is acceptable (some catalog renderings include it).
+        "CREATE INDEX idx_chunks_page_id ON docs.chunks USING btree (page_id);",
+    ],
+)
+def test_accepts_canonical_create_index(index_def: str) -> None:
+    result = _validate_index_def(index_def, "chunks")
+    assert result.lower().startswith("create")
+    assert "docs.chunks" in result.lower() or "chunks" in result.lower()
+
+
+@pytest.mark.parametrize(
+    "index_def",
+    [
+        # Stacked-statement injection.
+        "CREATE INDEX x ON docs.chunks (id); DROP TABLE docs.pages; --",
+        "CREATE INDEX x ON docs.chunks (id); CREATE INDEX y ON docs.chunks(id)",
+        # Wrong target table — refuses to touch anything other than chunks.
+        "CREATE INDEX x ON docs.other_table (id)",
+        "CREATE INDEX x ON docs.pg_class (id)",
+        # Outright non-CREATE-INDEX DDL.
+        "DROP TABLE docs.chunks",
+        "ALTER TABLE docs.chunks ADD COLUMN evil text",
+        "SELECT pg_sleep(10)",
+        "",
+    ],
+)
+def test_rejects_malicious_or_unexpected_definitions(index_def: str) -> None:
+    with pytest.raises(ValueError):
+        _validate_index_def(index_def, "chunks")
+
+
+def test_rejects_non_string() -> None:
+    with pytest.raises(ValueError):
+        _validate_index_def(None, "chunks")  # type: ignore[arg-type]

--- a/ingest/tests/test_index_def_validation.py
+++ b/ingest/tests/test_index_def_validation.py
@@ -9,7 +9,6 @@ SQL or target a table other than the importer's own chunks table.
 from __future__ import annotations
 
 import pytest
-
 from ingest.document_importer import _validate_index_def
 
 


### PR DESCRIPTION
## Summary

`DocumentImporter.finalize_database()` re-executes `CREATE INDEX` strings that were captured from `pg_indexes.indexdef` during `init_database()` and stashed on `self._index_defs_to_create`. Those strings are passed straight to `cur.execute(index_def)` with no validation. If the on-disk catalog entry for one of the chunks-table indexes is influenced by anyone other than the importer's role, the importer will faithfully run whatever DDL/DML it finds when it runs next — a textbook second-order SQL injection (CWE-89 / CWE-915 flavor).

- **File:** `ingest/document_importer.py`
- **Sink:** `cur.execute(index_def)` in `finalize_database()`
- **Source:** `SELECT indexdef FROM pg_indexes WHERE schemaname='docs' AND tablename = %s` in `init_database()`
- **Severity:** Medium — exploitation requires DDL access on `docs.<chunks_table>` by a role other than the importer (see preconditions below). Worth fixing because the importer is the most-privileged thing in this pipeline and the current code makes that trust completely implicit.

## Fix

A small allow-list validator, `_validate_index_def`, applied in two places:

1. In `init_database()` before storing each captured definition.
2. Again in `finalize_database()` immediately before `cur.execute(...)` as defence-in-depth, so a future refactor that bypasses the first call still can't smuggle SQL.

The validator:

- Requires the canonical `CREATE [UNIQUE] INDEX [IF NOT EXISTS] <name> ON [docs.]<table> …` shape that `pg_get_indexdef()` produces.
- Pins the target table to the importer's own `chunks_table` — anything else is rejected.
- Strips a single optional trailing `;` and rejects any other semicolon, blocking stacked statements.
- Rejects non-string input.

It returns the (trimmed) original string on success, so the executed SQL is unchanged for legitimate indexes.

## Tests

`ingest/tests/test_index_def_validation.py` covers:

- Canonical accepted forms: `CREATE INDEX`, `CREATE UNIQUE INDEX`, `USING btree`, `USING bm25 (...) WITH (key_field=id)`, trailing semicolon.
- Rejection of stacked statements (`CREATE INDEX … ; DROP TABLE …`), wrong target table (`docs.other_table`, `docs.pg_class`), non-`CREATE INDEX` DDL (`DROP TABLE`, `ALTER TABLE`, `SELECT pg_sleep`), empty string, and non-string input.

```
$ python -m pytest ingest/tests/test_index_def_validation.py -q
.............                                                            [100%]
13 passed in 0.32s
```

No production behavior changes for valid catalog state — the validator returns the same string `pg_get_indexdef()` rendered.

## Security analysis

Why this is reachable rather than purely theoretical: `init_database()` and `finalize_database()` run in two different transactions (with the swap-and-rename pattern in between), so anything that can write to the catalog between those two calls — or that influenced what got into the catalog before `init_database()` ran — gets its SQL executed by the importer's role at finalize time. The importer typically runs with `CREATE TABLE` / `DROP TABLE` rights in `docs`; that's strictly more than what an attacker needs to plant a malicious index definition.

Preconditions for exploitation:

1. Attacker has `CREATE INDEX` privilege on `docs.<chunks_table>`.
2. The importer runs with higher DB privileges than that attacker (typical multi-tenant / least-privilege deployment).
3. Attacker can get a non-canonical fragment through `pg_get_indexdef()`'s reconstruction. PostgreSQL canonicalises identifiers heavily, so this is the narrow part — but "narrow" is not "none", especially across PG versions and extensions like `pg_search` (`USING bm25 (...) WITH (...)`), and the validator removes the need to reason about it at all.

Mitigations the fix provides, even if you consider direct exploitation unlikely today:

- Removes an implicit-trust boundary between the importer and the Postgres catalog.
- Makes any future change to capture index defs from a wider scope (other schemas, other tables) fail loudly instead of silently executing.
- Documents the expected shape so reviewers don't have to re-derive it.

### Adversarial review

Before submitting, we tried to talk ourselves out of this one. The honest answer is that in a single-tenant deployment where only the importer's role can touch `docs.*`, you'd never hit this — `pg_get_indexdef()` would always reproduce exactly what the importer itself created. But there's no access-control or framework protection in the current code path that enforces that assumption: the executed string is whatever the catalog hands back, and the importer runs with enough privilege to do real damage if that string is hostile. The fix is ~70 lines, has no behavior change for valid input, and converts an implicit deployment assumption into an enforced invariant, which seemed worth a small PR.

cc @lewiswigmore
