### PR TITLE
Capture top search_docs results in logfire span

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@tigerdata/pg-aiguide",
       "dependencies": {
         "@ai-sdk/openai": "^2.0.80",
+        "@opentelemetry/api": "^1.9.0",
         "@tigerdata/mcp-boilerplate": "1.3.4",
         "ai": "^5.0.108",
         "dotenv": "^17.2.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.80",
+    "@opentelemetry/api": "^1.9.0",
     "@tigerdata/mcp-boilerplate": "1.3.4",
     "ai": "^5.0.108",
     "dotenv": "^17.2.3",

--- a/src/apis/searchDocs.ts
+++ b/src/apis/searchDocs.ts
@@ -1,4 +1,5 @@
 import { openai } from '@ai-sdk/openai';
+import { trace } from '@opentelemetry/api';
 import type { ApiFactory, InferSchema } from '@tigerdata/mcp-boilerplate';
 import { embed } from 'ai';
 import { z } from 'zod';
@@ -105,6 +106,33 @@ const outputSchema = {
 
 type OutputSchema = InferSchema<typeof outputSchema>;
 
+type SearchResult = SemanticResult | KeywordResult | HybridResult;
+
+const SEARCH_DOCS_SPAN_TOP_RESULT_COUNT = 3;
+
+function getResultScore(result: SearchResult): number {
+  if ('rrf_score' in result) return result.rrf_score;
+  if ('score' in result) return result.score;
+  return result.distance;
+}
+
+/**
+ * Records the ids and scores of the top results onto the active span so the
+ * search outcome is observable in Logfire. The matched document content is
+ * intentionally excluded to keep span attributes small.
+ */
+function recordTopResultsOnSpan(results: SearchResult[]): void {
+  const span = trace.getActiveSpan();
+  if (!span) return;
+
+  const topResults = results
+    .slice(0, SEARCH_DOCS_SPAN_TOP_RESULT_COUNT)
+    .map((result) => ({ id: result.id, score: getResultScore(result) }));
+
+  span.setAttribute('search_docs.result_count', results.length);
+  span.setAttribute('search_docs.top_results', JSON.stringify(topResults));
+}
+
 async function embedQueryJson(query: string): Promise<string> {
   const { embedding } = await embed({
     model: openai.embedding('text-embedding-3-small'),
@@ -166,18 +194,20 @@ export const searchDocsFactory: ApiFactory<
       passedSemanticWeight ?? SEARCH_DOCS_DEFAULT_SEMANTIC_WEIGHT;
 
     if (semanticWeight === 0) {
-      const result = await getDocChunkRows(chunkRowsCtx);
-      return { results: result as KeywordResult[] };
+      const result = (await getDocChunkRows(chunkRowsCtx)) as KeywordResult[];
+      recordTopResultsOnSpan(result);
+      return { results: result };
     }
 
     if (semanticWeight === 1) {
       const searchParam = await embedQueryJson(query);
-      const result = await getDocChunkRows({
+      const result = (await getDocChunkRows({
         ...chunkRowsCtx,
         semantic: true,
         searchParam,
-      });
-      return { results: result as SemanticResult[] };
+      })) as SemanticResult[];
+      recordTopResultsOnSpan(result);
+      return { results: result };
     }
 
     const hybridLimit = limit * SEARCH_DOCS_HYBRID_CANDIDATE_POOL_FACTOR;
@@ -222,7 +252,9 @@ export const searchDocsFactory: ApiFactory<
       };
     });
 
-    return { results: results as HybridResult[] };
+    const hybridResults = results as HybridResult[];
+    recordTopResultsOnSpan(hybridResults);
+    return { results: hybridResults };
   },
   pickResult: (r) => r.results,
 });

--- a/src/apis/searchDocs.ts
+++ b/src/apis/searchDocs.ts
@@ -194,20 +194,20 @@ export const searchDocsFactory: ApiFactory<
       passedSemanticWeight ?? SEARCH_DOCS_DEFAULT_SEMANTIC_WEIGHT;
 
     if (semanticWeight === 0) {
-      const result = (await getDocChunkRows(chunkRowsCtx)) as KeywordResult[];
-      recordTopResultsOnSpan(result);
-      return { results: result };
+      const results = (await getDocChunkRows(chunkRowsCtx)) as KeywordResult[];
+      recordTopResultsOnSpan(results);
+      return { results };
     }
 
     if (semanticWeight === 1) {
       const searchParam = await embedQueryJson(query);
-      const result = (await getDocChunkRows({
+      const results = (await getDocChunkRows({
         ...chunkRowsCtx,
         semantic: true,
         searchParam,
       })) as SemanticResult[];
-      recordTopResultsOnSpan(result);
-      return { results: result };
+      recordTopResultsOnSpan(results);
+      return { results };
     }
 
     const hybridLimit = limit * SEARCH_DOCS_HYBRID_CANDIDATE_POOL_FACTOR;
@@ -241,7 +241,7 @@ export const searchDocsFactory: ApiFactory<
       });
     }
 
-    const results = top.map(({ id, rrf_score }) => {
+    const results: HybridResult[] = top.map(({ id, rrf_score }) => {
       const row = byId.get(id);
       if (!row) throw new Error(`Missing chunk row for id ${id}`);
       return {
@@ -252,9 +252,8 @@ export const searchDocsFactory: ApiFactory<
       };
     });
 
-    const hybridResults = results as HybridResult[];
-    recordTopResultsOnSpan(hybridResults);
-    return { results: hybridResults };
+    recordTopResultsOnSpan(results);
+    return { results };
   },
   pickResult: (r) => r.results,
 });


### PR DESCRIPTION
## Summary

Captures information about `search_docs` results in the corresponding Logfire span, so search outcomes are observable in tracing. Only the `id` and `score` of the top 3 results are recorded — the matched document content is intentionally excluded to keep span attributes small.

<img width="1983" height="945" alt="image" src="https://github.com/user-attachments/assets/fa39129c-7ad2-40f5-b8b3-534acd5cb435" />

## Changes

- Added a `recordTopResultsOnSpan` helper that uses `trace.getActiveSpan()` (the MCP boilerplate already wraps each tool's `fn` in an active OTel/Logfire span) to set two attributes:
  - `search_docs.result_count` — total number of matches
  - `search_docs.top_results` — JSON array of the top 3 results, each with `id` and `score` only
- Added a `getResultScore` helper to normalize the differing score fields across result shapes (`rrf_score` for hybrid, `score` for keyword, `distance` for semantic).
- Wired the helper into all three return paths (keyword, semantic, hybrid).
- Added `@opentelemetry/api` as an explicit dependency.

## Testing

- `./bun test src/apis/searchDocs.test.ts` — all pass
- `./bun run typecheck` — `searchDocs.ts` clean (pre-existing unrelated error in `src/index.ts` remains)
